### PR TITLE
CDAP-14442 remove avro and parquet dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>5.1.0</cdap.version>
-    <hydrator.version>2.1.0</hydrator.version>
+    <hydrator.version>2.1.1-SNAPSHOT</hydrator.version>
     <data.pipeline.parent>system:cdap-data-pipeline[5.1.0,6.0.0-SNAPSHOT)</data.pipeline.parent>
     <data.stream.parent>system:cdap-data-streams[5.1.0,6.0.0-SNAPSHOT)</data.stream.parent>
     <hadoop.version>2.8.0</hadoop.version>
@@ -77,6 +77,16 @@
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-formats</artifactId>
       <version>${cdap.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.thekraken</groupId>
+          <artifactId>grok</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
@@ -196,33 +206,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro</artifactId>
-      <version>1.7.7</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-avro</artifactId>
-      <version>1.8.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.avro</groupId>
-          <artifactId>avro</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro-mapred</artifactId>
-      <classifier>hadoop2</classifier>
-      <version>1.7.7</version>
-    </dependency>
-    <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-      <version>2.9.1</version>
-    </dependency>
   </dependencies>
 
   <build>
@@ -245,12 +228,7 @@
           <configuration>
             <instructions>
               <_exportcontents>
-                co.cask.aws.s3.*;
-                co.cask.hydrator.format.*;
-                org.apache.avro.mapred.*;
-                org.apache.avro.mapreduce;
-                org.apache.parquet.avro.*;
-                org.apache.parquet.hadoop.*;
+                co.cask.aws.s3.*
               </_exportcontents>
               <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
               <Embed-Transitive>true</Embed-Transitive>


### PR DESCRIPTION
Formats are now in plugins. Removing them from the s3 plugins to
avoid classloading issues and reduce the jar sizes.