### PR TITLE
Depend on CDAP 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>5.0.0</cdap.version>
-    <hydrator.version>2.1.0-SNAPSHOT</hydrator.version>
-    <data.pipeline.parent>system:cdap-data-pipeline[5.0.0-SNAPSHOT,6.0.0-SNAPSHOT)</data.pipeline.parent>
-    <data.stream.parent>system:cdap-data-streams[5.0.0-SNAPSHOT,6.0.0-SNAPSHOT)</data.stream.parent>
+    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
+    <hydrator.version>2.2.0-SNAPSHOT</hydrator.version>
+    <data.pipeline.parent>system:cdap-data-pipeline[5.0.0-SNAPSHOT,7.0.0-SNAPSHOT)</data.pipeline.parent>
+    <data.stream.parent>system:cdap-data-streams[5.0.0-SNAPSHOT,7.0.0-SNAPSHOT)</data.stream.parent>
     <main.basedir>${project.basedir}</main.basedir>
   </properties>
 


### PR DESCRIPTION
We bumped cdap to 6.0.0-SNAPSHOT [here](https://github.com/caskdata/cdap/pull/10814)

Updating cdap dependency